### PR TITLE
add "What is Vizlab?" blog post to landing page

### DIFF
--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -28,7 +28,12 @@
           Email the team
         </h3>
         <div id="about-text-contact">
-          <p><a href="mailto:gs-w_vizlab@usgs.gov" target="_blank">gs-w_vizlab@usgs.gov</a></p>
+          <p>
+            <a
+              href="mailto:gs-w_vizlab@usgs.gov"
+              target="_blank"
+            >gs-w_vizlab@usgs.gov</a>
+          </p>
         </div>
       </div>
       <div id="follow-grp">

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -17,10 +17,20 @@
           What is the USGS Vizlab?
         </h3>
         <p>
-          The USGS Vizlab is a data visualization team that strives to make water science fun and accessible. We make charts, maps, and interactive websites to communicate USGS research and data. We are part of the <a
+          The USGS Vizlab is a data visualization team that strives to make water science fun and accessible. We make charts, maps, and interactive websites to communicate USGS research and data. We are part of the 
+          <a 
+          href="https://waterdata.usgs.gov/blog/water-data-science-2021/" 
+          target="_blank"
+          >Data Science Branch
+          </a>of the 
+          <a
             href="https://www.usgs.gov/mission-areas/water-resources"
             target="_blank"
-          >USGS Water Mission Area.</a>
+          >USGS Water Mission Area.
+          </a>
+          <br/>
+          <br />
+          We wrote a blog post about our work inn the <a href="https://waterdata.usgs.gov/blog/what-is-vizlab/" target="_blank" > Water Data for the Nation blog</a>.
         </p>
       </div>
       <div id="contact-grp">

--- a/src/components/ContentHeader.vue
+++ b/src/components/ContentHeader.vue
@@ -160,7 +160,7 @@ nav.usa-nav {
     padding: 0;
   }
   .usa-nav__primary.usa-accordion{
-    width: 100vw;
+    width: 95vw;
     margin-top: 0;
     margin-left: 0;
   }

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -12,64 +12,63 @@
     </div>
     <div id="right">
       <div id="right-grid">
-      <!-- wdfn blog links -->
-      <div id="viz-blog-title">
-        <a
-          href="https://waterdata.usgs.gov/blog/"
-          target="_blank"
-        >
-          <h2 id="title-blog">
-            <span
-              class="lowlight"
-              style="line-height: 10%"
-            >
-              Water Data Blog </span>
-          </h2></a>
-      </div>
-      <div id="viz-text">
-      
-        <div class="text-container">
-          <li>
-            <span class="date-text">
-              11/3/2021:
-            </span> 
-            We're hiring!  
-            <a
-              href="https://waterdata.usgs.gov/blog/viz-hires-2021/"
-              target="_blank"
-            >
-              <span class="arrow">
-                Read &#8594;
-              </span>
-            </a>
-          </li>
-          </div>
-           <div class="thumbnail-container">
-          <img 
-            class="blog-thumbnail"
-            src="https://labs.waterdata.usgs.gov/visualizations/thumbnails/viz-hires-dark.png" 
-            alt="an ad that the USGS Vizlab is hiring Data Visualization Specialists. Positions will be open to applicaiton son USAjobs from November 17th to the 23rd."
+        <!-- wdfn blog links -->
+        <div id="viz-blog-title">
+          <a
+            href="https://waterdata.usgs.gov/blog/"
+            target="_blank"
           >
+            <h2 id="title-blog">
+              <span
+                class="lowlight"
+                style="line-height: 10%"
+              >
+                Water Data Blog </span>
+            </h2></a>
         </div>
-        <div class="text-container">
-          <li>
-            <span class="date-text">5/18/2021:</span> A month of data viz for the #30DayChartChallenge  
-            <a
-              href="https://waterdata.usgs.gov/blog/30daychartchallenge-2021/"
-              target="_blank"
-            ><span class="arrow">Read &#8594;</span></a>
-          </li>
+        <div id="viz-text">
+          <div class="text-container">
+            <li>
+              <span class="date-text">
+                11/3/2021:
+              </span> 
+              We're hiring!  
+              <a
+                href="https://waterdata.usgs.gov/blog/viz-hires-2021/"
+                target="_blank"
+              >
+                <span class="arrow">
+                  Read &#8594;
+                </span>
+              </a>
+            </li>
+          </div>
+          <div class="thumbnail-container">
+            <img 
+              class="blog-thumbnail"
+              src="https://labs.waterdata.usgs.gov/visualizations/thumbnails/viz-hires-dark.png" 
+              alt="an ad that the USGS Vizlab is hiring Data Visualization Specialists. Positions will be open to applicaiton son USAjobs from November 17th to the 23rd."
+            >
+          </div>
+          <div class="text-container">
+            <li>
+              <span class="date-text">5/18/2021:</span> A month of data viz for the #30DayChartChallenge  
+              <a
+                href="https://waterdata.usgs.gov/blog/30daychartchallenge-2021/"
+                target="_blank"
+              ><span class="arrow">Read &#8594;</span></a>
+            </li>
 
-          <li>
-            <span class="date-text">3/29/2021:</span> Recreating the U.S. River Conditions animations in R  
-            <a
-              href="https://waterdata.usgs.gov/blog/build-r-animations/"
-              target="_blank"
-            ><span class="arrow">Read&#8594;</span></a>
-          </li>
+            <li>
+              <span class="date-text">3/29/2021:</span> Recreating the U.S. River Conditions animations in R  
+              <a
+                href="https://waterdata.usgs.gov/blog/build-r-animations/"
+                target="_blank"
+              ><span class="arrow">Read&#8594;</span></a>
+            </li>
+          </div>
         </div>
       </div>
-    </div>
     </div>
     <div id="viz-img">
       <div class="img-container">

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -27,7 +27,24 @@
             </h2></a>
         </div>
         <div id="viz-text">
+          <!-- blog list item -->
           <div class="text-container">
+            <li>
+              <span class="date-text">
+                11/10/2021:
+              </span> 
+              What is the USGS Vizlab? 
+              <a
+                href="https://waterdata.usgs.gov/blog/what-is-vizlab/"
+                target="_blank"
+              >
+                <span class="arrow">
+                  Read &#8594;
+                </span>
+              </a>
+            </li>
+          <!-- end blog list item -->
+          <!-- blog list item -->
             <li>
               <span class="date-text">
                 11/3/2021:
@@ -43,6 +60,8 @@
               </a>
             </li>
           </div>
+          <!-- end blog list item -->
+          <!-- include thumbnail of most recent blog post -->
           <div class="thumbnail-container">
             <img 
               class="blog-thumbnail"
@@ -50,6 +69,7 @@
               alt="an ad that the USGS Vizlab is hiring Data Visualization Specialists. Positions will be open to applicaiton son USAjobs from November 17th to the 23rd."
             >
           </div>
+          <!-- blog list item -->
           <div class="text-container">
             <li>
               <span class="date-text">5/18/2021:</span> A month of data viz for the #30DayChartChallenge  
@@ -67,10 +87,12 @@
               ><span class="arrow">Read&#8594;</span></a>
             </li>
           </div>
+          <!-- end blog list item -->
         </div>
       </div>
     </div>
     <div id="viz-img">
+      <!-- main featured graphic -->
       <div class="img-container">
         <img
           src="https://labs.waterdata.usgs.gov/visualizations/gifs/da-animated.gif"


### PR DESCRIPTION
Changes made:
-----------
Minor changes

Testing:
----------------------------
Before making this pull request, I:
- [x] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
