### PR TITLE
add vizlab tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,15 @@
 
       gtag('config', 'G-885PJEGWQ7');
     </script>
+    <!-- VIZLAB Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FWMWJQHLM6"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-FWMWJQHLM6');
+    </script>
     <!-- End gtag -->
    
     <meta charset="utf-8">


### PR DESCRIPTION
Changes made:
-----------
Adding a gtag that is shared across VizLab products to compare with product-specific tag data


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
