### PR TITLE
add water cycle blog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,6 @@
       gtag('config', 'G-885PJEGWQ7');
     </script>
     <!-- VIZLAB Google tag (gtag.js) -->
-    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-G4H936L4LV"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -19,15 +18,6 @@
       gtag('js', new Date());
 
       gtag('config', 'G-G4H936L4LV');
-    </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FWMWJQHLM6"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-FWMWJQHLM6');
     </script>
     <!-- End gtag -->
    

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -26,12 +26,27 @@
                 Water Data Blog </span>
             </h2></a>
         </div>
+        
         <div id="viz-text">
-          <!-- blog list item -->
+         <!-- blog list item -->
           <div class="text-container">
             <li>
               <span class="date-text">
-                09/08/2021:
+                01/04/2023:
+              </span> 
+              A New Take on the Water Cycle
+              <a
+                href="https://waterdata.usgs.gov/blog/water-cycle-release/"
+                target="_blank"
+              >
+                <span class="arrow">
+                  Read &#8594;
+                </span>
+              </a>
+            </li>
+            <li>
+              <span class="date-text">
+                09/08/2022:
               </span> 
               Water data science in 2022
               <a
@@ -332,7 +347,8 @@ a:active, a:focus {
     .blog-thumbnail {
   display: block;
   margin: auto;
-  max-width: 20vw;
+  width: 20vw;
+  max-width: 300px;
 }
 
     #viz-img {


### PR DESCRIPTION
Changes made:
-----------
Adding new water cycle blog


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
